### PR TITLE
Change xhr error to console.error instead of alert

### DIFF
--- a/js/releasehealth.js
+++ b/js/releasehealth.js
@@ -121,7 +121,7 @@ function getBugCounts(release) {
         }
       },
       error: function(jqXHR, textStatus, errorThrown) {
-        alert(textStatus);
+        console.error(textStatus);
       }
     });
   }


### PR DESCRIPTION
When these dashboards error on the office ambient displays, the synchronous alert blocks any automatic resetting of the screens.