### PR TITLE
Make Blocking Release query a bit faster

### DIFF
--- a/js/bzconfig.json
+++ b/js/bzconfig.json
@@ -20,7 +20,7 @@
     {
       "id": "blockingDiv",
       "title": "Blocking Release",
-      "url": "?v4=affected&f1=cf_tracking_firefox{RELEASE}&o3=equals&v3=---&o1=equals&j2=OR&f4=cf_status_firefox{RELEASE}&f3=cf_status_firefox{RELEASE}&f2=OP&o4=equals&f5=CP&v1=blocking&include_fields=id"
+      "url": "?resolution=---&resolution=FIXED&cf_tracking_firefox{RELEASE}=blocking&cf_status_firefox{RELEASE}=---&cf_status_firefox{RELEASE}=affected&include_fields=id"
     },
     {
       "id": "newRegressionDiv",
@@ -32,6 +32,6 @@
       "title": "Carryover Regressions",
       "url": "?v4=%3F&f10=resolution&o5=equals&n2=1&keywords=regression%2C&f1=cf_status_firefox{RELEASE}&keywords_type=allwords&o3=equals&f8=resolution&v11=INCOMPLETE&o11=notequals&v3=unaffected&j2=OR&o1=equals&o9=notequals&v10=WORKSFORME&f13=CP&f9=resolution&f4=cf_status_firefox{OLDERRELEASE}&v5=---&f12=resolution&o10=notequals&query_format=advanced&v9=WONTFIX&f3=cf_status_firefox{OLDERRELEASE}&o4=equals&f2=OP&v12=EXPIRED&f11=resolution&o12=notequals&f5=cf_status_firefox{OLDERRELEASE}&v8=INVALID&v1=affected&f6=CP&f7=OP&o8=notequals&f14=keywords&f15=priority&f16=priority&o14=notsubstring&o15=notequals&o16=notequals&v14=stalled&v15=p4&v16=p5&include_fields=id"
     }
-  ],  
+  ],
   "refreshMinutes": 30
 }


### PR DESCRIPTION
@jcristau says showing the Blocking Release number is slower than other two, which are in fact more complicated queries. One of the reasons is apparently the lack of `resolution`. When specifying the field, the request will be faster by 1.5s. It’s still slow, but better than now.