### PR TITLE
Issue #54: Add a FIXED BUGS count on skyline view

### DIFF
--- a/css/releasehealth.css
+++ b/css/releasehealth.css
@@ -216,6 +216,15 @@ footer #github .icon {
   background: url('../images/firefox_masterbrand.svg') no-repeat;
 }
 
+.skyline .bugcount {
+  padding: 2vmax;
+}
+
+.skyline .bugcount h2 {
+  font-size: 4vmax;
+}
+
+
 body:not(.skyline) .bugcount.skyline {
   display: none;
 }
@@ -224,6 +233,11 @@ body:not(.skyline) .bugcount.skyline {
   display: none;
 }
 
+@media (orientation: portrait) {
+  .skyline header h1 {
+    font-size: 5vmax;
+  }
+}
 @media screen and (min-width: 1024px) {
   .bugcount {
     flex-direction: column;

--- a/index.html
+++ b/index.html
@@ -22,8 +22,9 @@
       <div class="bugcount" id="newRegressionDiv"></div>
       <div class="bugcount" id="knowRegressionDiv"></div>
       <div class="bugcount skyline" id="skylineP1"></div>
-      <div class="bugcount skyline" id="skylineUntriaged"></div>
       <div class="bugcount skyline" id="skylineOpenNotP1"></div>
+      <div class="bugcount skyline" id="skylineUntriaged"></div>
+      <div class="bugcount skyline" id="skylineFixed"></div>
     </div>
     <footer>
       <nav>

--- a/js/bzconfig.json
+++ b/js/bzconfig.json
@@ -56,6 +56,11 @@
       "id": "skylineUntriaged",
       "title": "Untriaged",
       "url": "?query_format=advanced&status_whiteboard_type=allwordssubstr&status_whiteboard=%5Bskyline%5D&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&priority=--"
+    },
+    {
+      "id": "skylineFixed",
+      "title": "Fixed",
+      "url": "?query_format=advanced&status_whiteboard_type=allwordssubstr&status_whiteboard=%5Bskyline%5D&bug_status=RESOLVED"
     }
   ],
   "refreshMinutes": 30


### PR DESCRIPTION
css is modified on the skyline view to accomodate 4 columns or 4 rows on mobile.

Branch is on stage here:
https://tests.pascalc.net/releasehealth/?project=skyline