### PR TITLE
issue #60: Post-Skyline clean up of the dashboard:

### DIFF
--- a/css/releasehealth.css
+++ b/css/releasehealth.css
@@ -204,44 +204,6 @@ footer #github .icon {
   display: none;
 }
 
-/* Skyline rules, to be removed after the Skyline project */
-.skyline header,
-.skyline #diag,
-.skyline footer {
-  background-color: #20123a;
-  color: white;
-}
-
-.skyline header hgroup:before {
-  background: url('../images/firefox_masterbrand.svg') no-repeat;
-}
-
-.skyline #subtitle span {
-  display: none;
-}
-
-.skyline .bugcount {
-  padding: 2vmax;
-}
-
-.skyline .bugcount h2 {
-  font-size: 4vmax;
-}
-
-
-body:not(.skyline) .bugcount.skyline {
-  display: none;
-}
-
-.skyline .bugcount:not(.skyline) {
-  display: none;
-}
-
-@media (orientation: portrait) {
-  .skyline header h1 {
-    font-size: 5vmax;
-  }
-}
 @media screen and (min-width: 1024px) {
   .bugcount {
     flex-direction: column;

--- a/index.html
+++ b/index.html
@@ -21,10 +21,6 @@
       <div class="bugcount" id="blockingDiv"></div>
       <div class="bugcount" id="newRegressionDiv"></div>
       <div class="bugcount" id="knowRegressionDiv"></div>
-      <div class="bugcount skyline" id="skylineP1"></div>
-      <div class="bugcount skyline" id="skylineOpenNotP1"></div>
-      <div class="bugcount skyline" id="skylineUntriaged"></div>
-      <div class="bugcount skyline" id="skylineFixed"></div>
     </div>
     <footer>
       <nav>

--- a/js/bzconfig.json
+++ b/js/bzconfig.json
@@ -20,9 +20,9 @@
     }
   },
   "projects": {
-    "skyline": {
-      "title": "Skyline: Firefox",
-      "short_label": "Skyline",
+    "exampleProject": {
+      "title": "My project Title",
+      "short_label": "ShortTitle",
       "version": 70
     }
   },
@@ -41,26 +41,6 @@
       "id": "knowRegressionDiv",
       "title": "Carryover Regressions",
       "url": "?v4=%3F&f10=resolution&o5=equals&n2=1&keywords=regression%2C&f1=cf_status_firefox{RELEASE}&keywords_type=allwords&o3=equals&f8=resolution&v11=INCOMPLETE&o11=notequals&v3=unaffected&j2=OR&o1=equals&o9=notequals&v10=WORKSFORME&f13=CP&f9=resolution&f4=cf_status_firefox{OLDERRELEASE}&v5=---&f12=resolution&o10=notequals&query_format=advanced&v9=WONTFIX&f3=cf_status_firefox{OLDERRELEASE}&o4=equals&f2=OP&v12=EXPIRED&f11=resolution&o12=notequals&f5=cf_status_firefox{OLDERRELEASE}&v8=INVALID&v1=affected&f6=CP&f7=OP&o8=notequals&f14=keywords&f15=priority&f16=priority&o14=notsubstring&o15=notequals&o16=notequals&v14=stalled&v15=p4&v16=p5&include_fields=id"
-    },
-    {
-      "id": "skylineP1",
-      "title": "P1",
-      "url": "?query_format=advanced&status_whiteboard_type=allwordssubstr&status_whiteboard=%5Bskyline%5D&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&priority=P1&keywords=meta&keywords_type=nowords&f1=cf_status_firefox70&o1=anyexact&v1=affected%2C%20---%2C%3F"
-    },
-    {
-      "id": "skylineOpenNotP1",
-      "title": "P2-P5",
-      "url": "?query_format=advanced&status_whiteboard_type=allwordssubstr&status_whiteboard=%5Bskyline%5D&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&priority=P2&priority=P3&priority=P4&priority=P5&f1=cf_status_firefox70&o1=anyexact&v1=affected%2C%20---%2C%3F"
-    },
-    {
-      "id": "skylineUntriaged",
-      "title": "Untriaged",
-      "url": "?query_format=advanced&status_whiteboard_type=allwordssubstr&status_whiteboard=%5Bskyline%5D&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&priority=--&keywords=meta&keywords_type=nowords&f1=cf_status_firefox70&o1=anyexact&v1=affected%2C%20---%2C%3F"
-    },
-    {
-      "id": "skylineFixed",
-      "title": "Fixed",
-      "url": "?query_format=advanced&status_whiteboard_type=allwordssubstr&status_whiteboard=%5Bskyline%5D&bug_status=RESOLVED&keywords=meta&keywords_type=nowords"
     }
   ],
   "refreshMinutes": 30

--- a/js/releasehealth.js
+++ b/js/releasehealth.js
@@ -44,7 +44,7 @@ class ReleaseHealth {
   getProject() {
     const project = this.params.get('project');
 
-    return project && ['skyline'].includes(project) ? project : '';
+    return project && ['exampleProject'].includes(project) ? project : '';
   }
 
   /**
@@ -172,7 +172,9 @@ class ReleaseHealth {
     }
 
     for (const [id, { short_label }] of Object.entries(this.config.projects || {})) {
-      content += `<li><a href="?project=${id}">${short_label}</a></li>`;
+      if (id !== 'exampleProject') {
+        content += `<li><a href="?project=${id}">${short_label}</a></li>`;
+      }
     }
 
     document.querySelector('footer nav ul').innerHTML = content;


### PR DESCRIPTION
* Remove Skyline-specific content and queries (but keep Firefox masterbrand icon in tree)
* Keep the code to add projects in the dashboard
* Add a fake project as an example in bzconfig.json
* Call to ?project=skyline shows the default page (?channel=beta)

Branch is on https://tests.pascalc.net/releasehealth/?project=skyline