### PR TITLE
Fix issue #18: Don't include DUPLICATE bugs in queries

### DIFF
--- a/js/bzconfig.json
+++ b/js/bzconfig.json
@@ -35,12 +35,12 @@
     {
       "id": "newRegressionDiv",
       "title": "New Regressions",
-      "url": "?v4=%3F&f10=resolution&o5=equals&keywords=regression%2C&f1=cf_status_firefox{RELEASE}&keywords_type=allwords&o3=equals&f8=resolution&v11=INCOMPLETE&o11=notequals&v3=unaffected&j2=OR&o1=equals&o9=notequals&v10=WORKSFORME&f13=CP&f9=resolution&f4=cf_status_firefox{OLDERRELEASE}&v5=---&f12=resolution&o10=notequals&query_format=advanced&v9=WONTFIX&f3=cf_status_firefox{OLDERRELEASE}&o4=equals&f2=OP&v12=EXPIRED&f11=resolution&o12=notequals&f5=cf_status_firefox{OLDERRELEASE}&v8=INVALID&v1=affected&f6=CP&f7=OP&o8=notequals&f14=keywords&f15=priority&f16=priority&o14=notsubstring&o15=notequals&o16=notequals&v14=stalled&v15=p4&v16=p5&include_fields=id"
+      "url": "?v4=%3F&f10=resolution&o5=equals&keywords=regression%2C&f1=cf_status_firefox{RELEASE}&keywords_type=allwords&o3=equals&f8=resolution&v11=INCOMPLETE&o11=notequals&v3=unaffected&j2=OR&o1=equals&o9=notequals&v10=WORKSFORME&f13=CP&f9=resolution&f4=cf_status_firefox{OLDERRELEASE}&v5=---&f12=resolution&o10=notequals&query_format=advanced&v9=WONTFIX&f3=cf_status_firefox{OLDERRELEASE}&o4=equals&f2=OP&v12=EXPIRED&f11=resolution&o12=notequals&f5=cf_status_firefox{OLDERRELEASE}&v8=INVALID&v1=affected&f6=CP&f7=OP&o8=notequals&f14=keywords&f15=priority&f16=priority&o14=notsubstring&o15=notequals&o16=notequals&v14=stalled&v15=p4&v16=p5&include_fields=id&f17=resolution&o17=notequals&v17=DUPLICATE"
     },
     {
       "id": "knowRegressionDiv",
       "title": "Carryover Regressions",
-      "url": "?v4=%3F&f10=resolution&o5=equals&n2=1&keywords=regression%2C&f1=cf_status_firefox{RELEASE}&keywords_type=allwords&o3=equals&f8=resolution&v11=INCOMPLETE&o11=notequals&v3=unaffected&j2=OR&o1=equals&o9=notequals&v10=WORKSFORME&f13=CP&f9=resolution&f4=cf_status_firefox{OLDERRELEASE}&v5=---&f12=resolution&o10=notequals&query_format=advanced&v9=WONTFIX&f3=cf_status_firefox{OLDERRELEASE}&o4=equals&f2=OP&v12=EXPIRED&f11=resolution&o12=notequals&f5=cf_status_firefox{OLDERRELEASE}&v8=INVALID&v1=affected&f6=CP&f7=OP&o8=notequals&f14=keywords&f15=priority&f16=priority&o14=notsubstring&o15=notequals&o16=notequals&v14=stalled&v15=p4&v16=p5&include_fields=id"
+      "url": "?v4=%3F&f10=resolution&o5=equals&n2=1&keywords=regression%2C&f1=cf_status_firefox{RELEASE}&keywords_type=allwords&o3=equals&f8=resolution&v11=INCOMPLETE&o11=notequals&v3=unaffected&j2=OR&o1=equals&o9=notequals&v10=WORKSFORME&f13=CP&f9=resolution&f4=cf_status_firefox{OLDERRELEASE}&v5=---&f12=resolution&o10=notequals&query_format=advanced&v9=WONTFIX&f3=cf_status_firefox{OLDERRELEASE}&o4=equals&f2=OP&v12=EXPIRED&f11=resolution&o12=notequals&f5=cf_status_firefox{OLDERRELEASE}&v8=INVALID&v1=affected&f6=CP&f7=OP&o8=notequals&f14=keywords&f15=priority&f16=priority&o14=notsubstring&o15=notequals&o16=notequals&v14=stalled&v15=p4&v16=p5&include_fields=id&f17=resolution&o17=notequals&v17=DUPLICATE"
     }
   ],
   "refreshMinutes": 30


### PR DESCRIPTION
I put the branch there: https://tests.pascalc.net/releasehealth/?channel=nightly

The existing queries have these parameters appended:
`&f17=resolution&o17=notequals&v17=DUPLICATE`